### PR TITLE
Add missing dep on Microsoft.Bcl.Async that fixes runtime exceptions

### DIFF
--- a/InfluxDB.Net/InfluxDB.Net.nuspec
+++ b/InfluxDB.Net/InfluxDB.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>InfluxDB.Net</id>
-    <version>1.0.0-alpha</version>
+    <version>1.0.1-alpha</version>
     <title>InfluxDB.Net</title>
     <authors>Ziya SARIKAYA</authors>
     <owners>ziyasal</owners>
@@ -16,6 +16,7 @@
     <summary>Portable .NET client for InfluxDB.</summary>
     <copyright />
     <dependencies>
+      <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
       <dependency id="Newtonsoft.Json" version="6.0.5" />
       <dependency id="Microsoft.Net.Http" version="2.2.28" />
     </dependencies>


### PR DESCRIPTION
If the Microsoft.Bcl.Async package is missing at runtime, there will be really strange errors about Microsoft.Threading.Tasks being missing. 

Adding the dep to the nuspec fixes this.